### PR TITLE
Zabbix get status

### DIFF
--- a/actions/host_get_status.py
+++ b/actions/host_get_status.py
@@ -1,0 +1,31 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lib.actions import ZabbixBaseAction
+
+
+class HostGetStatus(ZabbixBaseAction):
+    def run(self, host=None, status=None):
+        """ Gets the status of a Zabbix Host.
+        """
+        self.connect()
+
+        # Find current host and populate self.zabbix_host
+        self.find_host(host)
+
+        # Get status from self.zabbix_host
+        host_status = self.zabbix_host['status']
+
+        return host_status

--- a/actions/host_get_status.yaml
+++ b/actions/host_get_status.yaml
@@ -1,0 +1,12 @@
+---
+name: host_get_status
+pack: zabbix
+runner_type: python-script
+description: Get the status of a Zabbix Host
+enabled: true
+entry_point: host_get_status.py
+parameters:
+    host:
+        type: string
+        description: "Name of the Zabbix Host"
+        required: True

--- a/tests/test_host_get_status.py
+++ b/tests/test_host_get_status.py
@@ -1,0 +1,49 @@
+import mock
+
+from zabbix_base_action_test_case import ZabbixBaseActionTestCase
+from host_get_status import HostGetStatus
+
+from urllib2 import URLError
+from pyzabbix.api import ZabbixAPIException
+
+
+class HostGetStatusTestCase(ZabbixBaseActionTestCase):
+    __test__ = True
+    action_cls = HostGetStatus
+
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_connection_error(self, mock_connect):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.side_effect = URLError('connection error')
+        test_dict = {'host': "test"}
+        host_dict = {'name': "test", 'hostid': '1'}
+        action.find_host = mock.MagicMock(return_value=host_dict['hostid'])
+
+        with self.assertRaises(URLError):
+            action.run(**test_dict)
+
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_host_error(self, mock_connect):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.return_vaue = "connect return"
+        test_dict = {'host': "test"}
+        host_dict = {'name': "test", 'hostid': '1'}
+        action.find_host = mock.MagicMock(return_value=host_dict['hostid'],
+            side_effect=ZabbixAPIException('host error'))
+        action.connect = mock_connect
+        with self.assertRaises(ZabbixAPIException):
+            action.run(**test_dict)
+
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    @mock.patch('lib.actions.ZabbixBaseAction.find_host')
+    def test_run(self, mock_connect, mock_find_host):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.return_vaue = "connect return"
+        test_dict = {'host': "test"}
+        host_dict = {'name': "test", 'hostid': '1', 'status': '0'}
+        action.connect = mock_connect
+        action.find_host = mock_find_host
+        action.zabbix_host = host_dict
+
+        result = action.run(**test_dict)
+        self.assertEqual(result, host_dict['status'])


### PR DESCRIPTION
Added additional action and required method to get the status of a Zabbix Host. Added tests for the new method.