### PR TITLE
Feature/multiple host race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.1.5
+
+- Added a new action `host_get_multiple_ids` that can retrieve 0, a single, or multiple zabbix hosts and
+  return those as an array. This is for a race condition that exists when using several zabbix proxies.
+  Contributed by Brad Bishop (Encore Technologies)
+
 ## 0.1.4
 
 - Added a new action `host_get_status` that retrieves the status of a host in Zabbix.

--- a/actions/host_get_multiple_ids.py
+++ b/actions/host_get_multiple_ids.py
@@ -1,42 +1,30 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lib.actions import ZabbixBaseAction
 from pyzabbix.api import ZabbixAPIException
-from urllib2 import URLError
-from zabbix.api import ZabbixAPI
-from st2common.runners.base_action import Action
 
 
-class ZabbixGetMultipleHostID(Action):
-    def __init__(self, config):
-        super(ZabbixGetMultipleHostID, self).__init__(config)
-        self.config = config
-
-        if self.config is not None and "zabbix" in self.config:
-            if "url" not in self.config['zabbix']:
-                raise ValueError("Zabbix url details not in the config.yaml")
-            elif "username" not in self.config['zabbix']:
-                raise ValueError("Zabbix user details not in the config.yaml")
-            elif "password" not in self.config['zabbix']:
-                raise ValueError("Zabbix password details not in the config.yaml")
-        else:
-            raise ValueError("Zabbix details not in the config.yaml")
-
-    def connect(self):
-        client = None
+class ZabbixGetMultipleHostID(ZabbixBaseAction):
+    def find_hosts(self, host_name):
+        """ Queries the zabbix api for a host and returns just the
+        ids of the hosts as a list. If a host could not be found it
+        returns an empty list.
+        """
         try:
-            client = ZabbixAPI(url=self.config['zabbix']['url'],
-                               user=self.config['zabbix']['username'],
-                               password=self.config['zabbix']['password'])
-        except ZabbixAPIException as e:
-            raise ZabbixAPIException("Failed to authenticate with Zabbix (%s)" % str(e))
-        except URLError as e:
-            raise URLError("Failed to connect to Zabbix Server (%s)" % str(e))
-        except KeyError:
-            raise KeyError("Configuration for Zabbix pack is not set yet")
-
-        return client
-
-    def find_hosts(self, client, host_name):
-        try:
-            zabbix_hosts = client.host.get(filter={"host": host_name})
+            zabbix_hosts = self.client.host.get(filter={"host": host_name})
         except ZabbixAPIException as e:
             raise ZabbixAPIException(("There was a problem searching for the host: "
                                     "{0}".format(e)))
@@ -49,8 +37,11 @@ class ZabbixGetMultipleHostID(Action):
         return zabbit_hosts_return
 
     def run(self, host=None):
-        client = self.connect()
+        """ Gets the IDs of the Zabbix host given the Hostname or FQDN
+        of the Zabbix host.
+        """
+        self.connect()
 
-        zabbix_hosts = self.find_hosts(client, host)
+        zabbix_hosts = self.find_hosts(host)
 
-        return (True, {'host_ids': zabbix_hosts})
+        return {'host_ids': zabbix_hosts}

--- a/actions/host_get_multiple_ids.py
+++ b/actions/host_get_multiple_ids.py
@@ -1,0 +1,56 @@
+from pyzabbix.api import ZabbixAPIException
+from urllib2 import URLError
+from zabbix.api import ZabbixAPI
+from st2common.runners.base_action import Action
+
+
+class ZabbixGetMultipleHostID(Action):
+    def __init__(self, config):
+        super(ZabbixGetMultipleHostID, self).__init__(config)
+        self.config = config
+
+        if self.config is not None and "zabbix" in self.config:
+            if "url" not in self.config['zabbix']:
+                raise ValueError("Zabbix url details not in the config.yaml")
+            elif "username" not in self.config['zabbix']:
+                raise ValueError("Zabbix user details not in the config.yaml")
+            elif "password" not in self.config['zabbix']:
+                raise ValueError("Zabbix password details not in the config.yaml")
+        else:
+            raise ValueError("Zabbix details not in the config.yaml")
+
+    def connect(self):
+        client = None
+        try:
+            client = ZabbixAPI(url=self.config['zabbix']['url'],
+                               user=self.config['zabbix']['username'],
+                               password=self.config['zabbix']['password'])
+        except ZabbixAPIException as e:
+            raise ZabbixAPIException("Failed to authenticate with Zabbix (%s)" % str(e))
+        except URLError as e:
+            raise URLError("Failed to connect to Zabbix Server (%s)" % str(e))
+        except KeyError:
+            raise KeyError("Configuration for Zabbix pack is not set yet")
+
+        return client
+
+    def find_hosts(self, client, host_name):
+        try:
+            zabbix_hosts = client.host.get(filter={"host": host_name})
+        except ZabbixAPIException as e:
+            raise ZabbixAPIException(("There was a problem searching for the host: "
+                                    "{0}".format(e)))
+
+        zabbit_hosts_return = []
+        if len(zabbix_hosts) > 0:
+            for host in zabbix_hosts:
+                zabbit_hosts_return.append(host['hostid'])
+
+        return zabbit_hosts_return
+
+    def run(self, host=None):
+        client = self.connect()
+
+        zabbix_hosts = self.find_hosts(client, host)
+
+        return (True, {'host_ids': zabbix_hosts})

--- a/actions/host_get_multiple_ids.yaml
+++ b/actions/host_get_multiple_ids.yaml
@@ -1,0 +1,12 @@
+---
+name: host_get_multiple_ids
+pack: zabbix
+runner_type: python-script
+description: Get the IDs of a multiple Zabbix Hosts if duplicates exist
+enabled: true
+entry_point: host_get_multiple_ids.py
+parameters:
+    host:
+        type: string
+        description: "Name of the Zabbix Host"
+        required: True

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: StackStorm pack that contains Zabbix integrations
 keywords:
   - zabbix
   - monitoring
-version: 0.1.4
+version: 0.1.5
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com

--- a/tests/test_host_get_multiple_ids.py
+++ b/tests/test_host_get_multiple_ids.py
@@ -1,0 +1,74 @@
+import mock
+
+from zabbix_base_action_test_case import ZabbixBaseActionTestCase
+from host_get_multiple_ids import ZabbixGetMultipleHostID
+
+from urllib2 import URLError
+from pyzabbix.api import ZabbixAPIException
+
+
+class GetMultipleHostIDTestCase(ZabbixBaseActionTestCase):
+    __test__ = True
+    action_cls = ZabbixGetMultipleHostID
+
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_connection_error(self, mock_connect):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.side_effect = URLError('connection error')
+        test_dict = {'host': "test"}
+        host_dict = {'name': "test", 'hostid': '1'}
+        action.find_host = mock.MagicMock(return_value=host_dict['hostid'])
+
+        with self.assertRaises(URLError):
+            action.run(**test_dict)
+
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_host_error(self, mock_connect):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.return_vaue = "connect return"
+        test_dict = {'host': "test"}
+        host_dict = {'name': "test", 'hostid': '1'}
+        action.find_hosts = mock.MagicMock(return_value=host_dict['hostid'],
+            side_effect=ZabbixAPIException('host error'))
+        action.connect = mock_connect
+        with self.assertRaises(ZabbixAPIException):
+            action.run(**test_dict)
+
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_none(self, mock_connect):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.return_vaue = "connect return"
+        test_dict = {'host': "test"}
+        action.connect = mock_connect
+        action.find_hosts = mock.MagicMock(return_value=[])
+        expected_return = {'host_ids': []}
+
+        result = action.run(**test_dict)
+        self.assertEqual(result, expected_return)
+
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_single(self, mock_connect):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.return_vaue = "connect return"
+        test_dict = {'host': "test"}
+        host_dict = {'name': "test", 'hostid': '1'}
+        action.connect = mock_connect
+        action.find_hosts = mock.MagicMock(return_value=[host_dict['hostid']])
+        expected_return = {'host_ids': [host_dict['hostid']]}
+
+        result = action.run(**test_dict)
+        self.assertEqual(result, expected_return)
+
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_multiple(self, mock_connect):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.return_vaue = "connect return"
+        test_dict = {'host': "test"}
+        host_dict = [{'name': "test", 'hostid': '1'}, {'name': "test", 'hostid': '2'}]
+        action.connect = mock_connect
+        action.find_hosts = mock.MagicMock(return_value=[host_dict[0]['hostid'],
+                                                        host_dict[1]['hostid']])
+        expected_return = {'host_ids': [host_dict[0]['hostid'], host_dict[1]['hostid']]}
+
+        result = action.run(**test_dict)
+        self.assertEqual(result, expected_return)


### PR DESCRIPTION
There is a known bug with Zabbix when using multiple proxies where multiple hosts get added with the same information. https://support.zabbix.com/browse/ZBX-11799

I added an action that will return all the hostids for a host or 0 if the host does not exist to add the ability to find and remediate this issue.

outputs:
```
$ st2 run zabbix.host_get_multiple_ids host='multiplehost.domain.tld'
.
id: 5b2d0cabed9fc84c0e3ec098
status: succeeded
parameters:
  host: multiplehost.domain.tld
result:
  exit_code: 0
  result:
    host_ids:
    - 'test1'
    - 'test2'
  stderr: ''
  stdout: ''


$ st2 run zabbix.host_get_multiple_ids host='nohost.domain.tld'
.
id: 5b2d1183ed9fc84c0e3ec09b
status: succeeded
parameters:
  host: nohost.domain.tld
result:
  exit_code: 0
  result:
    host_ids: []
  stderr: ''
  stdout: ''
```