### PR TITLE
Feature/delete by ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Added a new action `host_get_multiple_ids` that can retrieve 0, a single, or multiple zabbix hosts and
   return those as an array. This is for a race condition that exists when using several zabbix proxies.
-- Added a new action `host_delete_by_id` that allows a host to be deleted give the Host's ID instead of the
-  Host's Name
+- Added a new action `host_delete_by_id` that allows a host to be deleted given the Host's ID instead of 
+  the Host's Name
   Contributed by Brad Bishop (Encore Technologies)
 
 ## 0.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added a new action `host_get_multiple_ids` that can retrieve 0, a single, or multiple zabbix hosts and
   return those as an array. This is for a race condition that exists when using several zabbix proxies.
+- Added a new action `host_delete_by_id` that allows a host to be deleted give the Host's ID instead of the
+  Host's Name
   Contributed by Brad Bishop (Encore Technologies)
 
 ## 0.1.4

--- a/actions/host_delete.py
+++ b/actions/host_delete.py
@@ -18,13 +18,14 @@ from pyzabbix.api import ZabbixAPIException
 
 
 class HostDelete(ZabbixBaseAction):
-    def run(self, host=None):
+    def run(self, host=None, host_id=None):
         """ Updates the status of a Zabbix Host. Status needs to be
         1 or 0 for the call to succeed.
         """
         self.connect()
 
-        host_id = self.find_host(host)
+        if not host_id:
+            host_id = self.find_host(host)
 
         try:
             self.client.host.delete(host_id)

--- a/actions/host_delete.py
+++ b/actions/host_delete.py
@@ -19,8 +19,7 @@ from pyzabbix.api import ZabbixAPIException
 
 class HostDelete(ZabbixBaseAction):
     def run(self, host=None, host_id=None):
-        """ Updates the status of a Zabbix Host. Status needs to be
-        1 or 0 for the call to succeed.
+        """ Deletes a Zabbix Host.
         """
         self.connect()
 

--- a/actions/host_delete_by_id.yaml
+++ b/actions/host_delete_by_id.yaml
@@ -2,7 +2,7 @@
 name: host_delete_by_id
 pack: zabbix
 runner_type: python-script
-description: Delete a Zabbix Host by it's id
+description: Delete a Zabbix Host by it's Id
 enabled: true
 entry_point: host_delete.py
 parameters:

--- a/actions/host_delete_by_id.yaml
+++ b/actions/host_delete_by_id.yaml
@@ -1,0 +1,12 @@
+---
+name: host_delete_by_id
+pack: zabbix
+runner_type: python-script
+description: Delete a Zabbix Host by it's id
+enabled: true
+entry_point: host_delete.py
+parameters:
+    host_id:
+        type: string
+        description: "Id of the Zabbix Host"
+        required: True

--- a/tests/test_host_delete.py
+++ b/tests/test_host_delete.py
@@ -53,6 +53,20 @@ class HostDeleteTestCase(ZabbixBaseActionTestCase):
 
     @mock.patch('lib.actions.ZabbixAPI')
     @mock.patch('lib.actions.ZabbixBaseAction.connect')
+    def test_run_id(self, mock_connect, mock_client):
+        action = self.get_action_instance(self.full_config)
+        mock_connect.return_vaue = "connect return"
+        test_dict = {'host_id': "1"}
+        action.connect = mock_connect
+        mock_client.host.delete.return_value = "delete return"
+        action.client = mock_client
+
+        result = action.run(**test_dict)
+        mock_client.host.delete.assert_called_with(test_dict['host_id'])
+        self.assertEqual(result, True)
+
+    @mock.patch('lib.actions.ZabbixAPI')
+    @mock.patch('lib.actions.ZabbixBaseAction.connect')
     def test_run_delete_error(self, mock_connect, mock_client):
         action = self.get_action_instance(self.full_config)
         mock_connect.return_vaue = "connect return"


### PR DESCRIPTION
Added new action to add ability to delete a host by its id instead of searching for it by name first.

```
# st2 run zabbix.host_delete_by_id host_id="test1"
..
id: 5b2d488def13d80738fe4e63
status: succeeded
parameters: 
  host_id: 'test1'
result: 
  exit_code: 0
  result: true
  stderr: ''
  stdout: ''
```