### PR TITLE
update/zabbix-api-params-changed-in-v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.2.3
+### Updated
+- Updated py-zabbix module because the Zabbix API recently changed their login parameters
+
 ## 1.2.2
 ### Added
 - `actions/host_get_hostgroups` - Gets/Checks the hostgroups that a given Zabbix host is in

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description: Zabbix Monitoring System
 keywords:
   - zabbix
   - monitoring
-version: 1.2.2
+version: 1.2.3
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com
 python_versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/EncoreTechnologies/py-zabbix@update/zabbix-api-params-changed-in-v6
+git+https://github.com/EncoreTechnologies/py-zabbix
 st2client
 pytz
 tzlocal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-py-zabbix==1.1.3
+git+https://github.com/EncoreTechnologies/py-zabbix@update/zabbix-api-params-changed-in-v6
 st2client
 pytz
 tzlocal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/EncoreTechnologies/py-zabbix
+git+https://github.com/EncoreTechnologies/py-zabbix.git
 st2client
 pytz
 tzlocal


### PR DESCRIPTION
Updated py-zabbix module because the Zabbix API recently changed their login parameters.

This should only be merged after https://github.com/EncoreTechnologies/py-zabbix/pull/1 unless requirements.txt is updated to include that specific branch